### PR TITLE
fix: add cloud-init-main.service to ephemeral disk ordering dependency

### DIFF
--- a/ephemeral-disk-setup/azure-ephemeral-disk-setup.service
+++ b/ephemeral-disk-setup/azure-ephemeral-disk-setup.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Format and mount local ephemeral NVMe disks
-After=cloud-init.service cloud-init-network.service
+After=cloud-init.service cloud-init-main.service cloud-init-network.service
 After=local-fs.target
 DefaultDependencies=no
 Before=cloud-init.target

--- a/ephemeral-disk-setup/azure-ephemeral-disk-setup.service
+++ b/ephemeral-disk-setup/azure-ephemeral-disk-setup.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Format and mount local ephemeral NVMe disks
-After=cloud-init.service cloud-init-main.service cloud-init-network.service
+After=cloud-init.service cloud-init-main.service cloud-init-network.service cloud-init-local.service cloud-config.service cloud-final.service
 After=local-fs.target
 DefaultDependencies=no
 Before=cloud-init.target


### PR DESCRIPTION
cloud-init 24.3 introduced a "single process optimization" ([canonical/cloud-init#5489](https://github.com/canonical/cloud-init/pull/5489)) that renamed `cloud-init.service` to `cloud-init-main.service` and added `cloud-init-network.service`. This was merged on Aug 2, 2024 in commit [canonical/cloud-init@143bc9e](https://github.com/canonical/cloud-init/commit/143bc9e40f7f33695216db60f73e10a900d1d1cd).

The rename causes `azure-ephemeral-disk-setup.service` to reference a non-existent unit (`cloud-init.service`), resulting in a phantom systemd unit with `LOAD=not-found` and a silently broken `After=` ordering dependency. This means ephemeral disk setup may race with cloud-init provisioning.

## Fix

The fix adds `cloud-init-main.service` alongside `cloud-init.service` in the `After=` directive. systemd silently ignores ordering references to units that do not exist, so listing both names is backward-compatible:

- **cloud-init <24.3** (e.g. AZL3, RHEL 9): `cloud-init.service` exists, `cloud-init-main.service` is ignored.
- **cloud-init >=24.3** (e.g. AZL4): `cloud-init-main.service` exists, `cloud-init.service` is ignored.

## Reproduction

```bash
# On Azure Linux 4 (cloud-init 25.2):
systemctl list-units cloud-init.service --all --no-pager
# cloud-init.service  not-found  inactive  dead  cloud-init.service

grep cloud-init.service /usr/lib/systemd/system/azure-ephemeral-disk-setup.service
# After=cloud-init.service cloud-init-network.service
```

## References

- https://github.com/canonical/cloud-init/pull/5489
- https://discourse.ubuntu.com/t/announcement-cloud-init-perfomance-optimization-single-process/47505

> **BREAKING CHANGE WARNING from upstream cloud-init PR #5489:**
> "This definitely breaks backwards compatibility and will require downstream maintainers to update their vendored service files if they want to benefit from the performance improvements."